### PR TITLE
Added bin and pkg folder

### DIFF
--- a/bin/bin.md
+++ b/bin/bin.md
@@ -1,8 +1,11 @@
 # Binary Executables for Go 1.21
 
-- `main`: Main application binary
-- `mylib.a`: Compiled package file
+The `bin/` folder contains compiled executables generated from Go source files.
 
-## Build Details
-- Built using Go 1.21
-- Run `./bin/main` to execute
+## Contents:
+- `main`: The main application binary.
+
+## How to Use:
+1. Run the binary using:
+   ```sh
+   ./bin/main

--- a/bin/bin.md
+++ b/bin/bin.md
@@ -1,1 +1,8 @@
-# For all binany Executables (which we got after build)
+# Binary Executables for Go 1.21
+
+- `main`: Main application binary
+- `mylib.a`: Compiled package file
+
+## Build Details
+- Built using Go 1.21
+- Run `./bin/main` to execute

--- a/pkg/pkg.md
+++ b/pkg/pkg.md
@@ -1,1 +1,11 @@
-# Go Packages
+# Package Files for Go 1.21
+
+The `pkg/` folder contains compiled package files that can be reused across multiple Go projects.
+
+## Contents:
+- `mylib.a`: A compiled package file for `mypackage`, which provides reusable functions.
+
+## How to Use:
+1. Import the package in your Go project:
+   ```go
+   import "mypackage"


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Updated documentation for the `bin/` and `pkg/` folders to provide clear explanations of their contents and usage for Go 1.21 projects